### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_github/credentials.py
+++ b/prefect_github/credentials.py
@@ -3,7 +3,13 @@
 import warnings
 
 from prefect.blocks.abstract import CredentialsBlock
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
+
 from sgqlc.endpoint.http import HTTPEndpoint
 
 

--- a/prefect_github/repository.py
+++ b/prefect_github/repository.py
@@ -20,7 +20,13 @@ from prefect import task
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import run_process
-from pydantic import Field, validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, validator
+else:
+    from pydantic import Field, validator
+
 from sgqlc.operation import Operation
 
 from prefect_github import GitHubCredentials

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -5,7 +5,12 @@ from typing import Tuple
 
 import pytest
 from prefect.testing.utilities import AsyncMock
-from pydantic.error_wrappers import ValidationError
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1.error_wrappers import ValidationError
+else:
+    from pydantic.error_wrappers import ValidationError
 
 import prefect_github
 from prefect_github import GitHubCredentials


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.